### PR TITLE
Fixes typescript build failure comparing null | undefined

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -129,7 +129,7 @@ Apify.main(async () => {
     const crawler = new Apify.PuppeteerCrawler({
         requestQueue,
         handlePageFunction,
-        proxyConfiguration: proxyConfigurationObject,
+        proxyConfiguration: proxyConfigurationObject ?? undefined,
         maxRequestsPerCrawl,
         maxConcurrency,
         handlePageTimeoutSecs: timeoutForSingleUrlInSeconds,


### PR DESCRIPTION
@mhamas I came across an issue deploying this today, so I've made a patch for you.

The key issue is that in `node_modules/apify/types/proxy_configuration.d.ts`, we have:
```ts
export function createProxyConfiguration(proxyConfigurationOptions?: ProxyConfigurationOptions | undefined): Promise<ProxyConfiguration | null>;
```

Meaning `proxyConfigurationObject` is maybe `null`:

<img width="1344" alt="image" src="https://user-images.githubusercontent.com/1883112/113241784-d9077500-930b-11eb-8682-39345f549dd7.png">

But in `node_modules/apify/types/crawlers/puppeteer_crawler.d.ts`, we have:
```ts
proxyConfiguration?: any;
```
Which means it could be set or `undefined`, but not `null`:

<img width="1306" alt="image" src="https://user-images.githubusercontent.com/1883112/113241885-15d36c00-930c-11eb-94f1-b16931c77338.png">

The nullish-colleasing patch means if it's `null`, we make it `undefined` to keep TS happy.

Turning:
<img width="1400" alt="image" src="https://user-images.githubusercontent.com/1883112/113241964-44e9dd80-930c-11eb-8f97-301919a72d71.png">

into:
<img width="879" alt="image" src="https://user-images.githubusercontent.com/1883112/113241976-5337f980-930c-11eb-9950-cae72526be26.png">

